### PR TITLE
BUGFIX: Correct timezone offset for `Additional info` box

### DIFF
--- a/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Views/NodeInfoView.js
+++ b/TYPO3.Neos/Resources/Public/JavaScript/Content/Inspector/Views/NodeInfoView.js
@@ -9,7 +9,19 @@ function(
 	template
 ) {
 	Ember.Handlebars.registerBoundHelper('formatDate', function(value) {
-		return new Date(value).toISOString().slice(0, 16).replace('T', ' ');
+		function pad(n) {
+			return n < 10 ? '0' + n : n;
+		}
+		function formatDate(date) {
+			var Y = date.getFullYear().toString();
+			var m = (date.getMonth()+1).toString();
+			var d  = date.getDate().toString();
+			var h  = date.getHours().toString();
+			var i  = date.getMinutes().toString();
+			return Y + '-'+ pad(m) + '-' + pad(d) + ' ' + pad(h) + ':' +pad(i);
+		}
+
+		return formatDate(new Date(value));
 	});
 	return Ember.View.extend({
 		template: Ember.Handlebars.compile(template)


### PR DESCRIPTION
The time shown in the `Additional info` box now respects the timezone for the `Created`, `Last modification` and `Last publication` date of a node. Until now the time was shown in UTC and therefore off a couple of hours for most of the world.

NEOS-1807 #close
